### PR TITLE
Prepare package for PyPI distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Sphinx documentation
+docs/_build/

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,19 @@
-from distutils.core import setup
-
+from setuptools import setup
 
 setup(
-    name='v4l2',
-    version='0.2',
+    name='v4l2-python3',
+    version='0.3',
     license='GPLv2',
     requires=('ctypes',),
     py_modules=('v4l2',),
 
-    maintainer='python-v4l2-devel',
-    maintainer_email='https://launchpad.net/~python-v4l2-devel/+contactuser',
+    maintainer='Raspberry Pi Foundation',
+    maintainer_email='web@raspberrypi.org',
     url='http://pypi.python.org/pypi/v4l2',
     keywords='v4l2 video4linux video4linux2 binding ctypes',
     description='Python bindings for the v4l2 userspace api.',
 
-    classifiers=(
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License (GPL)',
@@ -23,5 +22,5 @@ setup(
         'Programming Language :: Python',
         'Topic :: Multimedia :: Video',
         'Topic :: Multimedia :: Video :: Capture',
-    ),
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
 
     maintainer='Raspberry Pi Foundation',
     maintainer_email='web@raspberrypi.org',
-    url='http://pypi.python.org/pypi/v4l2',
+    url='https://pypi.org/project/v4l2-python3/',
     keywords='v4l2 video4linux video4linux2 binding ctypes',
     description='Python bindings for the v4l2 userspace api.',
 


### PR DESCRIPTION
Prepares package for distribution via pip on PyPI.

PyPI doesn't allow direct links (eg. GitHub URLs) to packages in `install_requires`, eg. here for Picamera2: https://github.com/raspberrypi/picamera2/pull/53/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R26

In order to get around this, the v4l2 package needs publishing to PyPI.