### PR TITLE
fix: correct v4l2_frmsize_stepwise field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='v4l2-python3',
-    version='0.3.5',
+    version='0.3.6',
     license='GPLv2',
     requires=('ctypes',),
     py_modules=('v4l2',),

--- a/v4l2.py
+++ b/v4l2.py
@@ -507,7 +507,7 @@ class v4l2_frmsize_stepwise(ctypes.Structure):
         ('min_width', ctypes.c_uint32),
         ('min_height', ctypes.c_uint32),
         ('step_width', ctypes.c_uint32),
-        ('min_height', ctypes.c_uint32),
+        ('max_width', ctypes.c_uint32),
         ('max_height', ctypes.c_uint32),
         ('step_height', ctypes.c_uint32),
     ]


### PR DESCRIPTION
Replaced the duplicated field `min_height` with the correct field `max_width` in the `v4l2_frmsize_stepwise` structure.

The `v4l2_frmsize_stepwise` structure did not align with its definition in `linux/videodev2.h`, where it specifies a `max_width` field. 

This mismatch caused crashes when performing frame size enumeration (`VIDIOC_ENUM_FRAMESIZES`) with stepwise modes. 